### PR TITLE
feat: add SOCKET_PROXY_PORT environment variable

### DIFF
--- a/root/docker-entrypoint.sh
+++ b/root/docker-entrypoint.sh
@@ -2,10 +2,12 @@
 
 mkdir -p /run/haproxy
 
+PORT=${SOCKET_PROXY_PORT:-2375}
+
 if [ "${DISABLE_IPV6}" = 1 ]; then
-    BIND_PROTO=":2375"
+    BIND_PROTO=":${PORT}"
 else
-    BIND_PROTO="[::]:2375 v4v6"
+    BIND_PROTO="[::]:${PORT} v4v6"
 fi
 
 sed "s/@@BIND_PROTO@@/${BIND_PROTO}/g" /templates/haproxy.cfg > /run/haproxy/haproxy.cfg


### PR DESCRIPTION
Added new env SOCKET_PROXY_PORT that defaults to 2375 but is user changeable in rootless podman environments with `Network=host` as well as other cases.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x ] I have read the [contributing](https://github.com/linuxserver/docker-socket-proxy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This PR adds an optional `SOCKET_PROXY_PORT` environment variable to the `docker-entrypoint.sh` script. It allows users to override the default port (`2375`). If the variable is not set, it defaults to `2375` to ensure full backward compatibility.
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
This change is primarily to support `network=host` deployment configurations. When running in host networking mode, standard `Docker -p` or `PublishPort` mappings are ignored. Users are currently forced to use the hardcoded `2375` port, which leads to conflicts if other services on the host are already using it. This change provides the flexibility needed for hardened or complex production environments. This also addresses the request originally opened in issue #44.
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
I tested this by pulling the image and manually overriding the docker-entrypoint.sh logic on a local NUC. I verified that:
- Setting SOCKET_PROXY_PORT=9999 correctly updates the HAProxy configuration file to bind to port 9999.
- Leaving the variable unset defaults the configuration to 2375 as expected.
- IPv6 handling remains intact with the new port variable.
- The container starts and proxies the Docker socket correctly under both default and custom port configurations.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
Requested in issue: #44
<!--- Please include any forum posts/github links relevant to the PR -->
