### PR TITLE
Add docs for running rootless Podman as a non-root user

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -60,7 +60,7 @@ full_custom_readme: |
 
   ## Application Setup
 
-  This container is conceptually based on [https://github.com/Tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) and as such does not follow our usual container conventions. It *does not* support mods or custom scripts/services, or running as a user other than root (or the docker user in a rootless environment). It is designed to act as a drop-in replacement for the Tecnativa container.
+  This container is conceptually based on [https://github.com/Tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) and as such does not follow our usual container conventions. It *does not* support mods or custom scripts/services. It is designed to act as a drop-in replacement for the Tecnativa container.
 
   The container should be run on the same docker network as the service(s) using it. Most containers that would normally connect to a mounted docker.sock can have their endpoint overridden using the `DOCKER_HOST` environment variable if they do not offer the option in their configuration; it should typically be pointed to `tcp://socket-proxy:2375`.
 
@@ -86,6 +86,56 @@ full_custom_readme: |
   ```
 
   Point the exporter at `tcp://socket-proxy:2375` using `CONTAINER_HOST`. `LIBPOD_PING` and `LIBPOD_VERSION` are enabled by default (like their Docker-compat counterparts `PING` and `VERSION`).
+
+  ### Rootless Podman as a non-root user
+
+  Under rootless Podman the container process runs as `root` *inside its user namespace* by default. You can go a step further and drop root inside the container as well, running the proxy as an unprivileged user such as `nobody` (UID/GID `65534`). Two things need to be handled for this to work:
+
+  * **Socket ownership.** The rootless Podman socket (`$XDG_RUNTIME_DIR/podman/podman.sock`) is owned by your host user. That user maps to `root` inside the container's namespace, so a non-root user in the container cannot read it. Use `--userns=keep-id:uid=65534,gid=65534` to map your host user onto UID/GID `65534` inside the container, so `nobody` owns the socket and can proxy it.
+  * **A writable `/run`.** The entrypoint renders the HAProxy config into `/run/haproxy` at startup, so `/run` must be writable by the non-root user. Mount it as a tmpfs with `mode=1777` (this also satisfies read-only operation).
+
+  Example `podman run`:
+
+  ```bash
+  podman run -d \
+    --name=socket-proxy \
+    --user 65534:65534 \
+    --userns=keep-id:uid=65534,gid=65534 \
+    -e CONTAINERS=1 `#optional` \
+    -e LIBPOD_CONTAINERS=1 `#optional` \
+    -e POST=0 `#optional` \
+    -v $XDG_RUNTIME_DIR/podman/podman.sock:/var/run/docker.sock:ro \
+    -p 2375:2375 \
+    --read-only \
+    --tmpfs /run:rw,mode=1777 \
+    --restart unless-stopped \
+    lscr.io/linuxserver/socket-proxy:latest
+  ```
+
+  Or as a rootless [Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) unit (`~/.config/containers/systemd/socket-proxy.container`), started with `systemctl --user daemon-reload && systemctl --user start socket-proxy`:
+
+  ```ini
+  [Container]
+  ContainerName=socket-proxy
+  Image=lscr.io/linuxserver/socket-proxy:latest
+  User=65534:65534
+  UserNS=keep-id:uid=65534,gid=65534
+  Environment=CONTAINERS=1
+  Environment=LIBPOD_CONTAINERS=1
+  Environment=POST=0
+  Volume=%t/podman/podman.sock:/var/run/docker.sock:ro
+  PublishPort=2375:2375
+  ReadOnly=true
+  Tmpfs=/run:rw,mode=1777
+
+  [Install]
+  WantedBy=default.target
+  ```
+
+  (`%t` expands to `$XDG_RUNTIME_DIR`.) Enable the socket first with `systemctl --user enable --now podman.socket`.
+
+  > [!NOTE]
+  > On SELinux-enforcing hosts (e.g. Fedora/RHEL), add `--security-opt label=disable` to the `podman run` (or `SecurityLabelDisable=true` to the Quadlet) so the container can access the mounted socket.
 
   ## Read-Only Operation
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-socket-proxy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Document how to run the socket proxy as an unprivileged user (nobody, UID/GID 65534) under rootless Podman, in addition to the existing "docker user in a rootless environment" case where the container process still runs as root inside its namespace.

Covers the two requirements needed for this to work: mapping the host user onto the in-container user via --userns=keep-id so the mounted Podman socket is readable. Also providing a writable tmpfs /run so the entrypoint can render the HAProxy config. Includes a podman run example, a Quadlet unit, and an SELinux note.

## Benefits of this PR and context:

Urges users to use a non-root user inside the container. Also suppresses the HAProxy warning regarding this issue.

## How Has This Been Tested?

Good working of endpoints with a non-root user.
