### PR TITLE
Fix archive PUTs missing Content-Type

### DIFF
--- a/root/templates/haproxy.cfg
+++ b/root/templates/haproxy.cfg
@@ -25,6 +25,11 @@ backend docker
 
 frontend proxy
     bind @@BIND_PROTO@@
+    # Docker's archive extraction endpoint only consumes tar request bodies when
+    # their media type is application/x-tar. Supply the documented media type
+    # when clients omit Content-Type rather than forwarding a request that the
+    # daemon acknowledges with 200 while extracting nothing.
+    http-request set-header Content-Type application/x-tar if METH_PUT { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/archive$ } !{ req.hdr(Content-Type) -m found }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/start } { env(ALLOW_START) -m bool }
     http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/stop } { env(ALLOW_STOP) -m bool }


### PR DESCRIPTION
------------------------------

- [x] I have read the [contributing](https://github.com/linuxserver/docker-socket-proxy/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Default `Content-Type` to `application/x-tar` for Docker archive extraction PUT requests when the client omitted the header. Explicit client content types remain unchanged.

## Benefits of this PR and context:

Docker's `PUT /containers/{id}/archive` endpoint can return HTTP 200 while extracting nothing when the request has no `Content-Type`. That creates a silent-success failure mode for callers sending a valid tar body. Supplying the endpoint's documented media type at the proxy keeps header-less clients from receiving a false success.

The rule is restricted to PUT requests whose decoded path exactly matches the versioned or unversioned container archive endpoint.

## How Has This Been Tested?

Reproduced against Docker 24.0.9 through socket-proxy 3.4.2-r0-ls89:

- PUT of a valid tar without `Content-Type`: HTTP 200, subsequent archive GET returned 404.
- Identical PUT with `Content-Type: application/x-tar`: HTTP 200, subsequent archive GET returned 200.
- `git diff --check` passes.

A local HAProxy syntax check could not be run in the submitting environment because it lacks a Docker CLI and the deployed proxy denies container creation.

## Source / References:

- Docker Engine API, Extract an archive of files or folders to a directory in a container: https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Container/operation/ContainerArchive
